### PR TITLE
Added the ability to use an env var for the API URL.

### DIFF
--- a/schema-registry-cli/README.md
+++ b/schema-registry-cli/README.md
@@ -25,6 +25,13 @@ TODO
 
 ## Usage
 
+### Custom Schema Registry URL
+
+By default the commandline interface uses the default Schema Registry URL
+`http://localhost:8081`. You can add the `--url` argument to each subcommand,
+or you can use set the `SCHEMA_REGISTRY_URL` environment variable for a
+different API base URL.
+
 ### Show help
 
 ```console

--- a/schema-registry-cli/src/settings/mod.rs
+++ b/schema-registry-cli/src/settings/mod.rs
@@ -1,3 +1,4 @@
+use std::env;
 use std::str::FromStr;
 
 use clap::{Args, Parser, Subcommand};
@@ -47,13 +48,21 @@ const DEFAULT_SCHEMA_REGISTRY_URL: &str = "http://localhost:8081";
 #[derive(Debug, Clone, PartialEq, Args)]
 pub struct SchemaRegistrySettings {
     /// The schema registry URL
-    #[clap(short, long, default_value = DEFAULT_SCHEMA_REGISTRY_URL)]
+    #[clap(short, long, default_value_t = SchemaRegistrySettings::get_url_from_env())]
     pub url: Url,
+}
+
+impl SchemaRegistrySettings {
+    fn get_url_from_env() -> Url {
+        let input = env::var("SCHEMA_REGISTRY_URL")
+            .unwrap_or_else(|_| DEFAULT_SCHEMA_REGISTRY_URL.to_string());
+        Url::from_str(&input).expect("Valid URL")
+    }
 }
 
 impl Default for SchemaRegistrySettings {
     fn default() -> Self {
-        let url = Url::from_str(DEFAULT_SCHEMA_REGISTRY_URL).expect("Valid URL");
+        let url = Self::get_url_from_env();
         Self { url }
     }
 }


### PR DESCRIPTION
**- What is it good for**

Added the ability to configure the Schema Registry URL via an environment variable and documented this. 

**- What I did**

I just added a new method to the `SchemaRegistrySettings` struct which tries to fetch the URL from the environment variable, and if this fails it uses the default URL. This method is then used for the Clap parsing as default value. 

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://github.com/ilaborie/schema-registry-cli/assets/2496275/1697966e-5429-4aa8-b508-d69c0147f0ad)
