### PR TITLE
add `schemaType` to `Schema` struct

### DIFF
--- a/schema-registry-api/src/domain/schema/mod.rs
+++ b/schema-registry-api/src/domain/schema/mod.rs
@@ -33,7 +33,10 @@ impl Display for SchemaType {
 
 /// A Schema payload
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Schema {
+    /// The schema type
+    pub schema_type: Option<SchemaType>,
     /// The schema as string
     pub schema: String,
 }


### PR DESCRIPTION
Bonjour,

j'ai ajouté `schemaType` à la struct `Schema`. D'apres la spec openapi de schema-registry, ce champ fait partie de la response à` /schemas/ids/{id}`

https://github.com/confluentinc/schema-registry/blob/master/core/generated/swagger-ui/schema-registry-api-spec.yaml#L2284